### PR TITLE
Fast proving key marshalling

### DIFF
--- a/example/detail/r1cs_examples.hpp
+++ b/example/detail/r1cs_examples.hpp
@@ -29,7 +29,7 @@
 #ifndef CRYPTO3_R1CS_TVM_EXAMPLES_HPP
 #define CRYPTO3_R1CS_TVM_EXAMPLES_HPP
 
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 #include <nil/crypto3/algebra/random_element.hpp>
 

--- a/example/r1cs_gg_ppzksnark.cpp
+++ b/example/r1cs_gg_ppzksnark.cpp
@@ -31,8 +31,8 @@
 #include <nil/crypto3/algebra/pairing/mnt4.hpp>
 #include <nil/crypto3/algebra/pairing/mnt6.hpp>
 
-#include <nil/crypto3/zk/components/blueprint.hpp>
-#include <nil/crypto3/zk/components/blueprint_variable.hpp>
+#include <nil/crypto3/zk/blueprint/r1cs.hpp>
+#include <nil/crypto3/zk/blueprint/detail/r1cs/blueprint_variable.hpp>
 #include <nil/crypto3/zk/components/disjunction.hpp>
 
 #include <nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark.hpp>

--- a/include/nil/crypto3/marshalling/zk/types/fast_knowledge_commitment.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/fast_knowledge_commitment.hpp
@@ -1,0 +1,142 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017-2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2021 Ilias Khairullin <ilias@nil.foundation>
+// Copyright (c) 2022 Noam Y <@NoamDev>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_FAST_KNOWLEDGE_COMMITMENT_HPP
+#define CRYPTO3_MARSHALLING_FAST_KNOWLEDGE_COMMITMENT_HPP
+
+#include <ratio>
+#include <limits>
+#include <type_traits>
+
+#include <nil/marshalling/types/bundle.hpp>
+#include <nil/marshalling/types/array_list.hpp>
+#include <nil/marshalling/types/integral.hpp>
+#include <nil/marshalling/types/detail/adapt_basic_field.hpp>
+#include <nil/marshalling/status_type.hpp>
+#include <nil/marshalling/options.hpp>
+
+#include <nil/crypto3/algebra/type_traits.hpp>
+
+#include <nil/crypto3/container/sparse_vector.hpp>
+
+#include <nil/crypto3/marshalling/algebra/types/fast_curve_element.hpp>
+
+#include <nil/crypto3/zk/commitments/polynomial/knowledge_commitment.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace types {
+                template<
+                    typename TTypeBase,
+                    typename KnowledgeCommitment,
+                    typename = typename std::enable_if<
+                        std::is_same<KnowledgeCommitment,
+                                     zk::commitments::knowledge_commitment<typename KnowledgeCommitment::type1,
+                                                                           typename KnowledgeCommitment::type2>>::value,
+                        bool>::type,
+                    typename... TOptions>
+                using fast_knowledge_commitment =
+                    nil::marshalling::types::bundle<TTypeBase,
+                                                    std::tuple<
+                                                        // g
+                                                        fast_curve_element<TTypeBase, typename KnowledgeCommitment::type1>,
+                                                        // h
+                                                        fast_curve_element<TTypeBase, typename KnowledgeCommitment::type2>>>;
+
+                template<typename KnowledgeCommitment, typename Endianness>
+                fast_knowledge_commitment<nil::marshalling::field_type<Endianness>, KnowledgeCommitment>
+                    fill_fast_knowledge_commitment(const typename KnowledgeCommitment::value_type &kc) {
+
+                    auto filled_g = fill_fast_curve_element<typename KnowledgeCommitment::type1, Endianness>(kc.g);
+                    auto filled_h = fill_fast_curve_element<typename KnowledgeCommitment::type2, Endianness>(kc.h);
+
+                    return fast_knowledge_commitment<nil::marshalling::field_type<Endianness>, KnowledgeCommitment>(
+                        std::make_tuple(filled_g, filled_h));
+                }
+
+                template<typename KnowledgeCommitment, typename Endianness>
+                typename KnowledgeCommitment::value_type
+                    make_fast_knowledge_commitment(const fast_knowledge_commitment<nil::marshalling::field_type<Endianness>,
+                                                                         KnowledgeCommitment> &filled_kc) {
+
+                    return typename KnowledgeCommitment::value_type(std::move(make_fast_curve_element<typename KnowledgeCommitment::type1, Endianness>(std::get<0>(filled_kc.value()))),
+                                                                    std::move(make_fast_curve_element<typename KnowledgeCommitment::type2, Endianness>(std::get<1>(filled_kc.value()))));
+                }
+
+                template<typename KnowledgeCommitment, typename Endianness>
+                nil::marshalling::types::array_list<
+                    nil::marshalling::field_type<Endianness>,
+                    fast_knowledge_commitment<nil::marshalling::field_type<Endianness>, KnowledgeCommitment>,
+                    nil::marshalling::option::sequence_size_field_prefix<
+                        nil::marshalling::types::integral<nil::marshalling::field_type<Endianness>, std::size_t>>>
+                    fill_fast_knowledge_commitment_vector(
+                        const std::vector<typename KnowledgeCommitment::value_type> &kc_vector) {
+
+                    using TTypeBase = nil::marshalling::field_type<Endianness>;
+
+                    using kc_element_type = fast_knowledge_commitment<TTypeBase, KnowledgeCommitment>;
+
+                    using kc_element_vector_type = nil::marshalling::types::array_list<
+                        TTypeBase,
+                        kc_element_type,
+                        nil::marshalling::option::sequence_size_field_prefix<
+                            nil::marshalling::types::integral<nil::marshalling::field_type<Endianness>, std::size_t>>>;
+
+                    kc_element_vector_type result;
+
+                    std::vector<kc_element_type> &val = result.value();
+                    for (std::size_t i = 0; i < kc_vector.size(); i++) {
+                        val.push_back(fill_fast_knowledge_commitment<KnowledgeCommitment, Endianness>(kc_vector[i]));
+                    }
+                    return result;
+                }
+
+                template<typename KnowledgeCommitment, typename Endianness>
+                std::vector<typename KnowledgeCommitment::value_type> make_fast_knowledge_commitment_vector(
+                    const nil::marshalling::types::array_list<
+                        nil::marshalling::field_type<Endianness>,
+                        fast_knowledge_commitment<nil::marshalling::field_type<Endianness>, KnowledgeCommitment>,
+                        nil::marshalling::option::sequence_size_field_prefix<
+                            nil::marshalling::types::integral<nil::marshalling::field_type<Endianness>, std::size_t>>>
+                        &filled_kc_vector) {
+
+                    std::vector<typename KnowledgeCommitment::value_type> result;
+                    const std::vector<
+                        fast_knowledge_commitment<nil::marshalling::field_type<Endianness>, KnowledgeCommitment>> &values =
+                        filled_kc_vector.value();
+                    std::size_t size = values.size();
+
+                    for (std::size_t i = 0; i < size; i++) {
+                        result.push_back(make_fast_knowledge_commitment<KnowledgeCommitment, Endianness>(values[i]));
+                    }
+                    return result;
+                }
+            }    // namespace types
+        }        // namespace marshalling
+    }            // namespace crypto3
+}    // namespace nil
+#endif    // CRYPTO3_MARSHALLING_FAST_KNOWLEDGE_COMMITMENT_HPP

--- a/include/nil/crypto3/marshalling/zk/types/plonk/constraint.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/plonk/constraint.hpp
@@ -34,7 +34,7 @@
 #include <nil/marshalling/status_type.hpp>
 #include <nil/marshalling/options.hpp>
 
-#include <nil/crypto3/zk/snark/relations/plonk/constraint.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint.hpp>
 
 #include <nil/crypto3/marshalling/zk/types/math/non_linear_combination.hpp>
 

--- a/include/nil/crypto3/marshalling/zk/types/plonk/gate.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/plonk/gate.hpp
@@ -36,7 +36,7 @@
 
 #include <nil/crypto3/marshalling/algebra/types/field_element.hpp>
 
-#include <nil/crypto3/zk/snark/relations/plonk/gate.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/gate.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/auxiliary_input.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/auxiliary_input.hpp
@@ -41,7 +41,7 @@
 
 #include <nil/crypto3/algebra/type_traits.hpp>
 
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 #include <nil/crypto3/marshalling/algebra/types/field_element.hpp>
 

--- a/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/fast_proving_key.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/fast_proving_key.hpp
@@ -1,0 +1,191 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2021 Ilias Khairullin <ilias@nil.foundation>
+// Copyright (c) 2022 Noam Y <@NoamDev>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_R1CS_GG_PPZKSNARK_FAST_PROVING_KEY_HPP
+#define CRYPTO3_MARSHALLING_R1CS_GG_PPZKSNARK_FAST_PROVING_KEY_HPP
+
+#include <ratio>
+#include <limits>
+#include <type_traits>
+
+#include <nil/marshalling/types/bundle.hpp>
+#include <nil/marshalling/types/array_list.hpp>
+#include <nil/marshalling/types/integral.hpp>
+#include <nil/marshalling/types/tag.hpp>
+#include <nil/marshalling/types/detail/adapt_basic_field.hpp>
+#include <nil/marshalling/status_type.hpp>
+#include <nil/marshalling/options.hpp>
+
+#include <nil/crypto3/algebra/type_traits.hpp>
+
+#include <nil/crypto3/container/accumulation_vector.hpp>
+#include <nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark/proving_key.hpp>
+
+#include <nil/crypto3/marshalling/algebra/types/field_element.hpp>
+#include <nil/crypto3/marshalling/algebra/types/fast_curve_element.hpp>
+#include <nil/crypto3/marshalling/zk/types/accumulation_vector.hpp>
+#include <nil/crypto3/marshalling/zk/types/sparse_vector.hpp>
+#include <nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/r1cs.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace types {
+                template<typename TTypeBase,
+                         typename ProvingKey,
+                         typename = typename std::enable_if<
+                             std::is_same<ProvingKey,
+                                          zk::snark::r1cs_gg_ppzksnark_proving_key<
+                                              typename ProvingKey::curve_type,
+                                              typename ProvingKey::constraint_system_type>>::value,
+                             bool>::type,
+                         typename... TOptions>
+                using r1cs_gg_ppzksnark_fast_proving_key = nil::marshalling::types::bundle<
+                    TTypeBase,
+                    std::tuple<
+                        // alpha_g1
+                        fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g1_type<>>,
+                        // beta_g1
+                        fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g1_type<>>,
+                        // beta_g2
+                        fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g2_type<>>,
+                        // delta_g1
+                        fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g1_type<>>,
+                        // delta_g2
+                        fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g2_type<>>,
+                        // A_query
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g1_type<>>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>>,
+                        // B_query
+                        fast_knowledge_commitment_sparse_vector<TTypeBase,
+                                                           nil::crypto3::zk::commitments::knowledge_commitment_vector<
+                                                               typename ProvingKey::curve_type::template g2_type<>,
+                                                               typename ProvingKey::curve_type::template g1_type<>>>,
+                        // H_query
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g1_type<>>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>>,
+                        // L_query
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g1_type<>>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>>,
+                        // constraint_system
+                        r1cs_constraint_system<TTypeBase, typename ProvingKey::constraint_system_type>>>;
+
+                template<typename ProvingKey, typename Endianness>
+                r1cs_gg_ppzksnark_fast_proving_key<nil::marshalling::field_type<Endianness>, ProvingKey>
+                    fill_r1cs_gg_ppzksnark_fast_proving_key(const ProvingKey &proving_key) {
+
+                    using TTypeBase = nil::marshalling::field_type<Endianness>;
+                    using curve_g1_element_type =
+                        fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g1_type<>>;
+                    using curve_g2_element_type =
+                        fast_curve_element<TTypeBase, typename ProvingKey::curve_type::template g2_type<>>;
+
+                    return r1cs_gg_ppzksnark_fast_proving_key<TTypeBase, ProvingKey>(std::make_tuple(
+                        std::move(
+                            fill_fast_curve_element<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                proving_key.alpha_g1)),
+                        std::move(
+                            fill_fast_curve_element<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                proving_key.beta_g1)),
+                        std::move(
+                            fill_fast_curve_element<typename ProvingKey::curve_type::template g2_type<>, Endianness>(
+                                proving_key.beta_g2)),
+                        std::move(
+                            fill_fast_curve_element<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                proving_key.delta_g1)),
+                        std::move(
+                            fill_fast_curve_element<typename ProvingKey::curve_type::template g2_type<>, Endianness>(
+                                proving_key.delta_g2)),
+                        std::move(
+                            fill_fast_curve_element_vector<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                proving_key.A_query)),
+                        std::move(fill_fast_knowledge_commitment_sparse_vector<
+                                  nil::crypto3::zk::commitments::knowledge_commitment_vector<
+                                      typename ProvingKey::curve_type::template g2_type<>,
+                                      typename ProvingKey::curve_type::template g1_type<>>,
+                                  Endianness>(proving_key.B_query)),
+                        std::move(
+                            fill_fast_curve_element_vector<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                proving_key.H_query)),
+                        std::move(
+                            fill_fast_curve_element_vector<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                proving_key.L_query)),
+                        std::move(fill_r1cs_constraint_system<typename ProvingKey::constraint_system_type, Endianness>(
+                            proving_key.constraint_system))));
+                }
+
+                template<typename ProvingKey, typename Endianness>
+                ProvingKey make_r1cs_gg_ppzksnark_fast_proving_key(
+                    const r1cs_gg_ppzksnark_fast_proving_key<nil::marshalling::field_type<Endianness>, ProvingKey>
+                        &filled_proving_key) {
+
+                    return ProvingKey(
+                        std::move(
+                            make_fast_curve_element<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                std::get<0>(filled_proving_key.value()))),
+                        std::move(
+                            make_fast_curve_element<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                std::get<1>(filled_proving_key.value()))),
+                        std::move(
+                            make_fast_curve_element<typename ProvingKey::curve_type::template g2_type<>, Endianness>(
+                                std::get<2>(filled_proving_key.value()))),
+                        std::move(
+                            make_fast_curve_element<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                std::get<3>(filled_proving_key.value()))),
+                        std::move(
+                            make_fast_curve_element<typename ProvingKey::curve_type::template g2_type<>, Endianness>(
+                                std::get<4>(filled_proving_key.value()))),
+                        std::move(
+                            make_fast_curve_element_vector<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                std::get<5>(filled_proving_key.value()))),
+                        std::move(
+                            make_fast_knowledge_commitment_vector<nil::crypto3::zk::commitments::knowledge_commitment_vector<
+                                                                 typename ProvingKey::curve_type::template g2_type<>,
+                                                                 typename ProvingKey::curve_type::template g1_type<>>,
+                                                             Endianness>(std::get<6>(filled_proving_key.value()))),
+                        std::move(
+                            make_fast_curve_element_vector<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                std::get<7>(filled_proving_key.value()))),
+                        std::move(
+                            make_fast_curve_element_vector<typename ProvingKey::curve_type::template g1_type<>, Endianness>(
+                                std::get<8>(filled_proving_key.value()))),
+                        std::move(make_r1cs_constraint_system<typename ProvingKey::constraint_system_type, Endianness>(
+                            std::get<9>(filled_proving_key.value()))));
+                }
+            }    // namespace types
+        }        // namespace marshalling
+    }            // namespace crypto3
+}    // namespace nil
+#endif    // CRYPTO3_MARSHALLING_R1CS_GG_PPZKSNARK_FAST_PROVING_KEY_HPP

--- a/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/primary_input.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/primary_input.hpp
@@ -40,7 +40,7 @@
 
 #include <nil/crypto3/algebra/type_traits.hpp>
 
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 #include <nil/crypto3/marshalling/algebra/types/field_element.hpp>
 #include <nil/crypto3/marshalling/algebra/types/curve_element.hpp>

--- a/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/r1cs.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/r1cs.hpp
@@ -42,7 +42,7 @@
 #include <nil/crypto3/container/sparse_vector.hpp>
 
 #include <nil/crypto3/marshalling/algebra/types/curve_element.hpp>
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/test/detail/r1cs_examples.hpp
+++ b/test/detail/r1cs_examples.hpp
@@ -29,7 +29,7 @@
 #ifndef CRYPTO3_MARSHALLING_R1CS_GG_PPZKSNARK_EXAMPLES_HPP
 #define CRYPTO3_MARSHALLING_R1CS_GG_PPZKSNARK_EXAMPLES_HPP
 
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 #include <nil/crypto3/algebra/random_element.hpp>
 

--- a/test/detail/sha256_component.hpp
+++ b/test/detail/sha256_component.hpp
@@ -29,7 +29,7 @@
 #include <nil/crypto3/zk/components/hashes/sha256/sha256_component.hpp>
 #include <nil/crypto3/zk/components/hashes/hash_io.hpp>
 
-#include <nil/crypto3/zk/components/blueprint.hpp>
+#include <nil/crypto3/zk/blueprint/r1cs.hpp>
 
 #include <nil/crypto3/hash/sha2.hpp>
 

--- a/test/r1cs_gg_ppzksnark.cpp
+++ b/test/r1cs_gg_ppzksnark.cpp
@@ -40,8 +40,8 @@
 #include <nil/crypto3/algebra/pairing/mnt4.hpp>
 #include <nil/crypto3/algebra/pairing/mnt6.hpp>
 
-#include <nil/crypto3/zk/components/blueprint.hpp>
-#include <nil/crypto3/zk/components/blueprint_variable.hpp>
+#include <nil/crypto3/zk/blueprint/r1cs.hpp>
+#include <nil/crypto3/zk/blueprint/detail/r1cs/blueprint_variable.hpp>
 #include <nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark.hpp>
 #include <nil/crypto3/zk/algorithms/generate.hpp>
 #include <nil/crypto3/zk/algorithms/verify.hpp>


### PR DESCRIPTION
This adds an alternative marhsalling scheme for proving key using the fast curve element marshalling introduced in NilFoundation/crypto3-algebra-marshalling/pull/13.
This PR therefore depends on the merging of the above PR first.
Again, this allows for 100x faster deserialization but takes about 2 times space.