### PR TITLE
Necessary marshalling for GROTH16 MPC 

### DIFF
--- a/include/nil/crypto3/marshalling/zk/types/powers_of_tau/accumulator.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/powers_of_tau/accumulator.hpp
@@ -1,0 +1,167 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2021 Ilias Khairullin <ilias@nil.foundation>
+// Copyright (c) 2022 Noam Y <@NoamDev>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_POWERS_OF_TAO_ACCUMULATOR_HPP
+#define CRYPTO3_MARSHALLING_POWERS_OF_TAO_ACCUMULATOR_HPP
+
+#include <ratio>
+#include <limits>
+#include <type_traits>
+
+#include <nil/marshalling/types/bundle.hpp>
+#include <nil/marshalling/types/array_list.hpp>
+#include <nil/marshalling/types/integral.hpp>
+#include <nil/marshalling/types/tag.hpp>
+#include <nil/marshalling/types/detail/adapt_basic_field.hpp>
+#include <nil/marshalling/status_type.hpp>
+#include <nil/marshalling/options.hpp>
+
+#include <nil/crypto3/algebra/type_traits.hpp>
+
+#include <nil/crypto3/container/accumulation_vector.hpp>
+#include <nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark/powers_of_tau/accumulator.hpp>
+
+#include <nil/crypto3/marshalling/algebra/types/field_element.hpp>
+#include <nil/crypto3/marshalling/algebra/types/fast_curve_element.hpp>
+#include <nil/crypto3/marshalling/zk/types/accumulation_vector.hpp>
+#include <nil/crypto3/marshalling/zk/types/sparse_vector.hpp>
+#include <nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/r1cs.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace types {
+                template<typename TTypeBase,
+                         typename Accumulator,
+                         typename = typename std::enable_if<
+                             std::is_same<Accumulator,
+                                          zk::snark::powers_of_tau_accumulator<
+                                              typename Accumulator::curve_type,
+                                              Accumulator::policy_type::tau_powers_length>>::value,
+                             bool>::type,
+                         typename... TOptions>
+                using powers_of_tau_accumulator = nil::marshalling::types::bundle<
+                    TTypeBase,
+                    std::tuple<
+                        // tau_powers_g1
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            fast_curve_element<TTypeBase, typename Accumulator::curve_type::template g1_type<>>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>>,
+                        // tau_powers_g2
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            fast_curve_element<TTypeBase, typename Accumulator::curve_type::template g2_type<>>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>>,
+                        // alpha_tau_powers_g1
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            fast_curve_element<TTypeBase, typename Accumulator::curve_type::template g1_type<>>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>>,
+                        // beta_tau_powers_g1
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            fast_curve_element<TTypeBase, typename Accumulator::curve_type::template g1_type<>>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>>,
+                        // beta_g2
+                        fast_curve_element<TTypeBase, typename Accumulator::curve_type::template g2_type<>>
+                    >>;
+
+                template<typename Accumulator, typename Endianness>
+                powers_of_tau_accumulator<nil::marshalling::field_type<Endianness>, Accumulator>
+                    fill_powers_of_tau_accumulator(const Accumulator &accumulator) {
+
+                    using TTypeBase = nil::marshalling::field_type<Endianness>;
+                    using curve_g1_element_type =
+                        fast_curve_element<TTypeBase, typename Accumulator::curve_type::template g1_type<>>;
+                    using curve_g2_element_type =
+                        fast_curve_element<TTypeBase, typename Accumulator::curve_type::template g2_type<>>;
+
+                    return powers_of_tau_accumulator<TTypeBase, Accumulator>(std::make_tuple(
+                        std::move(
+                            fill_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                                accumulator.tau_powers_g1)),
+                        std::move(
+                            fill_fast_curve_element_vector<typename Accumulator::curve_type::template g2_type<>, Endianness>(
+                                accumulator.tau_powers_g2)),
+                        std::move(
+                            fill_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                                accumulator.alpha_tau_powers_g1)),
+                        std::move(
+                            fill_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                                accumulator.beta_tau_powers_g1)),
+                        std::move(
+                            fill_fast_curve_element<typename Accumulator::curve_type::template g2_type<>, Endianness>(
+                                accumulator.beta_g2))));
+                }
+
+                // template<typename Accumulator, typename Endianness>
+                // Accumulator make_r1cs_gg_ppzksnark_fast_proving_key(
+                //     const r1cs_gg_ppzksnark_fast_proving_key<nil::marshalling::field_type<Endianness>, Accumulator>
+                //         &filled_proving_key) {
+
+                //     return Accumulator(
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<0>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<1>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g2_type<>, Endianness>(
+                //                 std::get<2>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<3>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g2_type<>, Endianness>(
+                //                 std::get<4>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<5>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_knowledge_commitment_vector<nil::crypto3::zk::commitments::knowledge_commitment_vector<
+                //                                                  typename Accumulator::curve_type::template g2_type<>,
+                //                                                  typename Accumulator::curve_type::template g1_type<>>,
+                //                                              Endianness>(std::get<6>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<7>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<8>(filled_proving_key.value()))),
+                //         std::move(make_r1cs_constraint_system<typename Accumulator::constraint_system_type, Endianness>(
+                //             std::get<9>(filled_proving_key.value()))));
+                // }
+            }    // namespace types
+        }        // namespace marshalling
+    }            // namespace crypto3
+}    // namespace nil
+#endif    // CRYPTO3_MARSHALLING_POWERS_OF_TAO_ACCUMULATOR_HPP

--- a/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/mpc/mpc_params.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/mpc/mpc_params.hpp
@@ -1,0 +1,125 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2021 Ilias Khairullin <ilias@nil.foundation>
+// Copyright (c) 2022 Noam Y <@NoamDev>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_MPC_PARAMS_HPP
+#define CRYPTO3_MARSHALLING_MPC_PARAMS_HPP
+
+#include <ratio>
+#include <limits>
+#include <type_traits>
+
+#include <nil/marshalling/types/bundle.hpp>
+#include <nil/marshalling/types/array_list.hpp>
+#include <nil/marshalling/types/integral.hpp>
+#include <nil/marshalling/types/tag.hpp>
+#include <nil/marshalling/types/detail/adapt_basic_field.hpp>
+#include <nil/marshalling/status_type.hpp>
+#include <nil/marshalling/options.hpp>
+
+#include <nil/crypto3/algebra/type_traits.hpp>
+
+#include <nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark/mpc_generator/mpc_params.hpp>
+#include <nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/fast_proving_key.hpp>
+#include <nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/verification_key.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace types {
+                template<typename TTypeBase,
+                         typename MPCParams,
+                         typename = typename std::enable_if<
+                             std::is_same<MPCParams,
+                                          zk::snark::r1cs_gg_ppzksnark_mpc_params<
+                                              typename MPCParams::curve_type>>::value,
+                             bool>::type,
+                         typename... TOptions>
+                using r1cs_gg_ppzksnark_mpc_params = nil::marshalling::types::bundle<
+                    TTypeBase,
+                    std::tuple<
+                        r1cs_gg_ppzksnark_fast_proving_key<TTypeBase, typename MPCParams::proving_scheme_type::keypair_type::first_type>,
+                        r1cs_gg_ppzksnark_verification_key<TTypeBase, typename MPCParams::proving_scheme_type::keypair_type::second_type>
+                    >>;
+
+                template<typename MPCParams, typename Endianness>
+                r1cs_gg_ppzksnark_mpc_params<nil::marshalling::field_type<Endianness>, MPCParams>
+                    fill_r1cs_gg_ppzksnark_mpc_params(const MPCParams &mpc_params) {
+
+                    using TTypeBase = nil::marshalling::field_type<Endianness>;
+
+                    return r1cs_gg_ppzksnark_mpc_params<TTypeBase, MPCParams>(std::make_tuple(
+                        std::move(
+                            fill_r1cs_gg_ppzksnark_fast_proving_key<typename MPCParams::proving_scheme_type::keypair_type::first_type, Endianness>(
+                                mpc_params.keypair.first)),
+                        std::move(
+                            fill_r1cs_gg_ppzksnark_verification_key<typename MPCParams::proving_scheme_type::keypair_type::second_type, Endianness>(
+                                mpc_params.keypair.second))
+                        ));
+                }
+
+                // template<typename Accumulator, typename Endianness>
+                // Accumulator make_r1cs_gg_ppzksnark_fast_proving_key(
+                //     const r1cs_gg_ppzksnark_fast_proving_key<nil::marshalling::field_type<Endianness>, Accumulator>
+                //         &filled_proving_key) {
+
+                //     return Accumulator(
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<0>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<1>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g2_type<>, Endianness>(
+                //                 std::get<2>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<3>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element<typename Accumulator::curve_type::template g2_type<>, Endianness>(
+                //                 std::get<4>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<5>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_knowledge_commitment_vector<nil::crypto3::zk::commitments::knowledge_commitment_vector<
+                //                                                  typename Accumulator::curve_type::template g2_type<>,
+                //                                                  typename Accumulator::curve_type::template g1_type<>>,
+                //                                              Endianness>(std::get<6>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<7>(filled_proving_key.value()))),
+                //         std::move(
+                //             make_fast_curve_element_vector<typename Accumulator::curve_type::template g1_type<>, Endianness>(
+                //                 std::get<8>(filled_proving_key.value()))),
+                //         std::move(make_r1cs_constraint_system<typename Accumulator::constraint_system_type, Endianness>(
+                //             std::get<9>(filled_proving_key.value()))));
+                // }
+            }    // namespace types
+        }        // namespace marshalling
+    }            // namespace crypto3
+}    // namespace nil
+#endif    // CRYPTO3_MARSHALLING_MPC_PARAMS_HPP

--- a/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/mpc/public_key.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/r1cs_gg_ppzksnark/mpc/public_key.hpp
@@ -1,0 +1,108 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2022 Noam Y <@NoamDev>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_R1CS_GG_PPZKSNARK_MPC_PUBLIC_KEY_HPP
+#define CRYPTO3_MARSHALLING_R1CS_GG_PPZKSNARK_MPC_PUBLIC_KEY_HPP
+
+#include <ratio>
+#include <limits>
+#include <type_traits>
+
+#include <nil/marshalling/types/bundle.hpp>
+#include <nil/marshalling/types/array_list.hpp>
+#include <nil/marshalling/types/integral.hpp>
+#include <nil/marshalling/types/detail/adapt_basic_field.hpp>
+#include <nil/marshalling/status_type.hpp>
+#include <nil/marshalling/options.hpp>
+
+#include <nil/crypto3/algebra/type_traits.hpp>
+
+#include <nil/crypto3/container/accumulation_vector.hpp>
+
+#include <nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark/mpc_generator/public_key.hpp>
+
+#include <nil/crypto3/marshalling/algebra/types/fast_curve_element.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace types {
+
+                template<typename TTypeBase,
+                         typename PublicKey,
+                         typename = typename std::enable_if<
+                             std::is_same<PublicKey,
+                                          zk::snark::r1cs_gg_ppzksnark_mpc_generator_public_key<typename PublicKey::curve_type>>::value,
+                             bool>::type,
+                         typename... TOptions>
+                using r1cs_gg_ppzksnark_mpc_generator_public_key = nil::marshalling::types::bundle<
+                    TTypeBase,
+                    std::tuple<
+                        // delta after
+                        fast_curve_element<TTypeBase, typename PublicKey::curve_type::template g1_type<>>,
+                        // delta_pok.g1_s
+                        fast_curve_element<TTypeBase, typename PublicKey::curve_type::template g1_type<>>,
+                        // delta_pok.g1_s_x
+                        fast_curve_element<TTypeBase, typename PublicKey::curve_type::template g1_type<>>,
+                        // delta_pok.g2_s_x
+                        fast_curve_element<TTypeBase, typename PublicKey::curve_type::template g2_type<>>>>;
+
+                template<typename PublicKey, typename Endianness>
+                r1cs_gg_ppzksnark_mpc_generator_public_key<nil::marshalling::field_type<Endianness>, PublicKey>
+                    fill_r1cs_gg_ppzksnark_mpc_generator_public_key(const PublicKey &public_key) {
+
+                    using TTypeBase = nil::marshalling::field_type<Endianness>;
+
+                    return r1cs_gg_ppzksnark_mpc_generator_public_key<nil::marshalling::field_type<Endianness>, PublicKey>(
+                        std::make_tuple(
+                            std::move(
+                                fill_fast_curve_element<typename PublicKey::curve_type::template g1_type<>, Endianness>(
+                                    public_key.delta_after)),
+                            std::move(
+                                fill_fast_curve_element<typename PublicKey::curve_type::template g1_type<>, Endianness>(
+                                    public_key.delta_pok.g1_s)),
+                            std::move(
+                                fill_fast_curve_element<typename PublicKey::curve_type::template g1_type<>, Endianness>(
+                                    public_key.delta_pok.g1_s_x)),
+                            std::move(
+                                fill_fast_curve_element<typename PublicKey::curve_type::template g2_type<>, Endianness>(
+                                    public_key.delta_pok.g2_s_x))
+                        ));
+                }
+
+                // template<typename ProofType, typename Endianness>
+                // ProofType make_r1cs_gg_ppzksnark_proof(
+                //     const r1cs_gg_ppzksnark_proof<nil::marshalling::field_type<Endianness>, ProofType>
+                //         &filled_r1cs_gg_ppzksnark_proof) {
+
+                //     return ProofType(std::move(std::get<0>(filled_r1cs_gg_ppzksnark_proof.value()).value()),
+                //                      std::move(std::get<1>(filled_r1cs_gg_ppzksnark_proof.value()).value()),
+                //                      std::move(std::get<2>(filled_r1cs_gg_ppzksnark_proof.value()).value()));
+                // }
+
+            }    // namespace types
+        }        // namespace marshalling
+    }            // namespace crypto3
+}    // namespace nil
+#endif    // CRYPTO3_MARSHALLING_R1CS_GG_PPZKSNARK_PROOF_HPP


### PR DESCRIPTION
Some necessary marshallings used in https://github.com/NilFoundation/crypto3-zk/pull/77 for types defined there.
Admittedly the current implementation is incomplete, it only includes the serialization part