### PR TITLE
Remove blueprint dependency from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,6 @@ target_link_libraries(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTERFACE
                       crypto3::multiprecision
                       crypto3::algebra
                       crypto3::zk
-                      crypto3::blueprint
                       crypto3::pubkey
                       crypto3::pkpad
                       crypto3::containers


### PR DESCRIPTION
Blueprint was removed from Crypto3.
This line breaks building projects with Crypto3, resulting in the following error:

```
CMake Error at cmake/modules/share/modules/cmake/CMFuture.cmake:83 (_add_library):
  Target "zkllvm_circuit" links to target "crypto3::blueprint" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```

Part of nilfoundation/zkllvm-template#12