### PR TITLE
Modified marshalling types to no longer rely on ArithmetizationParams. [SyncWith: crypto3-zk#292]

### DIFF
--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -28,15 +28,16 @@ jobs:
 
       targets: ${{ inputs.targets }} 
 
-  matrix-test-mac:
-    name: Mac Reusable Crypto3 Testing
-    needs:
-      - handle-syncwith
-    uses: NilFoundation/ci-cd/.github/workflows/reusable-crypto3-testing-mac.yml@v1.2.0
-
-    secrets: inherit
-    with:
-      submodules-refs: ${{ needs.handle-syncwith.outputs.prs-refs }}
-
-      targets: ${{ inputs.targets }} 
+# Temporarily disabling this, most of our tests fail on mac, we have a separate task/issue for fixing this.
+#  matrix-test-mac:
+#    name: Mac Reusable Crypto3 Testing
+#    needs:
+#      - handle-syncwith
+#    uses: NilFoundation/ci-cd/.github/workflows/reusable-crypto3-testing-mac.yml@v1.2.0
+#
+#    secrets: inherit
+#    with:
+#      submodules-refs: ${{ needs.handle-syncwith.outputs.prs-refs }}
+#
+#      targets: ${{ inputs.targets }} 
 

--- a/include/nil/crypto3/marshalling/zk/types/placeholder/common_data.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/placeholder/common_data.hpp
@@ -140,10 +140,12 @@ namespace nil {
                 ){
                     auto fixed_values = make_commitment<Endianness, typename CommonDataType::commitment_scheme_type>(std::get<0>(filled_common_data.value()));
 
-                    typename CommonDataType::columns_rotations_type columns_rotations;
+                    typename CommonDataType::columns_rotations_type columns_rotations(
+                        std::get<1>(filled_common_data.value()).value().size()
+                    );
                     for(size_t i = 0; i < std::get<1>(filled_common_data.value()).value().size(); i++){
                         auto filled_column = std::get<1>(filled_common_data.value()).value().at(i);
-                        for(size_t j = 0; j < filled_column.value().size(); j++){
+                        for(size_t j = 0; j < filled_column.value().size(); j++) {
                             columns_rotations[i].insert(filled_column.value()[j].value());
                         }
                     }

--- a/include/nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp
@@ -127,17 +127,9 @@ namespace nil {
                     const std::size_t columns_amount,
                     const std::size_t rows_amount) {
 
-                    std::vector<std::vector<FieldValueType>> result;
-                    result.resize(columns_amount);
-                    for (std::size_t i = 0; i < columns_amount; i++) {
-                        result[i].resize(rows_amount);
-                    }
-                    if (field_elem_vector.value().size() != columns_amount * rows_amount) {
-                        throw std::invalid_argument(
-                            "Field element vector size should be equal to columns amount * rows amount. Field element vector size = " +
-                            std::to_string(field_elem_vector.value().size()) +
-                            ", columns amount * rows amount = " + std::to_string(columns_amount * rows_amount));
-                    }
+                    std::vector<std::vector<FieldValueType>> result(
+                        columns_amount, std::vector<FieldValueType>(rows_amount));
+                    BOOST_ASSERT(field_elem_vector.value().size() == columns_amount * rows_amount);
                     std::size_t cur = 0;
                     for (std::size_t i = 0; i < columns_amount; i++) {
                         for (std::size_t j = 0; j < rows_amount; j++, cur++) {

--- a/include/nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp
@@ -105,11 +105,10 @@ namespace nil {
                     field_element_vector_type result;
                     result.value().reserve(size * columns.size());
                     for (std::size_t column_number = 0; column_number < columns.size(); column_number++) {
-                        std::size_t i = 0;
-                        for (; i < columns[column_number].size(); i++) {
+                        for (std::size_t i = 0; i < columns[column_number].size(); i++) {
                             result.value().push_back(field_element_type(columns[column_number][i]));
                         }
-                        for (; i < size; i++) {
+                        for (std::size_t i = columns[column_number].size(); i < size; i++) {
                             result.value().push_back(field_element_type(padding));
                         }
                     }

--- a/include/nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp
+++ b/include/nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp
@@ -28,14 +28,14 @@
 #include <type_traits>
 
 #include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/table_description.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp>
 
 #include <nil/marshalling/types/bundle.hpp>
 #include <nil/marshalling/types/array_list.hpp>
 #include <nil/marshalling/types/integral.hpp>
 #include <nil/marshalling/status_type.hpp>
 #include <nil/marshalling/options.hpp>
-
-#include <nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp>
 
 namespace nil {
     namespace crypto3 {
@@ -45,16 +45,107 @@ namespace nil {
                 template<typename TTypeBase, typename PlonkTable>
                 using plonk_assignment_table = nil::marshalling::types::bundle<
                     TTypeBase, std::tuple<
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>, // witness_amount
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>, // public_input_amount
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>, // constant_amount
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>, // selector_amount
+
                         nil::marshalling::types::integral<TTypeBase, std::size_t>, // usable_rows
-                        nil::marshalling::types::integral<TTypeBase, std::size_t>, // columns_number
-                        // table_values
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>, // rows_amount
+                        // witnesses
                         nil::marshalling::types::array_list<
                             TTypeBase,
                             field_element<TTypeBase, typename PlonkTable::field_type::value_type>,
-                            nil::marshalling::option::sequence_size_field_prefix<nil::marshalling::types::integral<TTypeBase, std::size_t>>
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>
+                        >,
+                        // public_inputs
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            field_element<TTypeBase, typename PlonkTable::field_type::value_type>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>
+                        >,
+                        // constants
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            field_element<TTypeBase, typename PlonkTable::field_type::value_type>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>
+                        >,
+                        // selectors
+                        nil::marshalling::types::array_list<
+                            TTypeBase,
+                            field_element<TTypeBase, typename PlonkTable::field_type::value_type>,
+                            nil::marshalling::option::sequence_size_field_prefix<
+                                nil::marshalling::types::integral<TTypeBase, std::size_t>>
                         >
                     >
                 >;
+
+                template<typename FieldValueType, typename Endianness>
+                nil::marshalling::types::array_list<
+                    nil::marshalling::field_type<Endianness>,
+                    field_element<nil::marshalling::field_type<Endianness>, FieldValueType>,
+                    nil::marshalling::option::sequence_size_field_prefix<
+                        nil::marshalling::types::integral<nil::marshalling::field_type<Endianness>, std::size_t>>>
+                    fill_field_element_vector_from_columns_with_padding(
+                        const std::vector<std::vector<FieldValueType>> &columns,
+                        const std::size_t size,
+                        const FieldValueType &padding) {
+
+                    using TTypeBase = nil::marshalling::field_type<Endianness>;
+                    using field_element_type = field_element<TTypeBase, FieldValueType>;
+                    using field_element_vector_type = nil::marshalling::types::array_list<
+                        TTypeBase,
+                        field_element_type,
+                        nil::marshalling::option::sequence_size_field_prefix<
+                            nil::marshalling::types::integral<TTypeBase, std::size_t>>>;
+
+                    field_element_vector_type result;
+                    result.value().reserve(size * columns.size());
+                    for (std::size_t column_number = 0; column_number < columns.size(); column_number++) {
+                        std::size_t i = 0;
+                        for (; i < columns[column_number].size(); i++) {
+                            result.value().push_back(field_element_type(columns[column_number][i]));
+                        }
+                        for (; i < size; i++) {
+                            result.value().push_back(field_element_type(padding));
+                        }
+                    }
+                    return result;
+                }
+
+                template<typename FieldValueType, typename Endianness>
+                std::vector<std::vector<FieldValueType>> make_field_element_columns_vector(
+                    const nil::marshalling::types::array_list<
+                        nil::marshalling::field_type<Endianness>,
+                        field_element<nil::marshalling::field_type<Endianness>, FieldValueType>,
+                        nil::marshalling::option::sequence_size_field_prefix<
+                            nil::marshalling::types::integral<nil::marshalling::field_type<Endianness>, std::size_t>>>
+                        &field_elem_vector,
+                    const std::size_t columns_amount,
+                    const std::size_t rows_amount) {
+
+                    std::vector<std::vector<FieldValueType>> result;
+                    result.resize(columns_amount);
+                    for (std::size_t i = 0; i < columns_amount; i++) {
+                        result[i].resize(rows_amount);
+                    }
+                    if (field_elem_vector.value().size() != columns_amount * rows_amount) {
+                        throw std::invalid_argument(
+                            "Field element vector size should be equal to columns amount * rows amount. Field element vector size = " +
+                            std::to_string(field_elem_vector.value().size()) +
+                            ", columns amount * rows amount = " + std::to_string(columns_amount * rows_amount));
+                    }
+                    std::size_t cur = 0;
+                    for (std::size_t i = 0; i < columns_amount; i++) {
+                        for (std::size_t j = 0; j < rows_amount; j++, cur++) {
+                            result[i][j] = field_elem_vector.value()[cur].value();
+                        }
+                    }
+                    return result;
+                }
 
                 template<typename Endianness, typename PlonkTable>
                 plonk_assignment_table<nil::marshalling::field_type<Endianness>, PlonkTable> fill_assignment_table(
@@ -63,86 +154,84 @@ namespace nil {
                 ){
                     using TTypeBase = nil::marshalling::field_type<Endianness>;
                     using result_type = plonk_assignment_table<nil::marshalling::field_type<Endianness>, PlonkTable>;
+                    using value_type = typename PlonkTable::field_type::value_type;
 
-                    std::vector<typename PlonkTable::field_type::value_type> table_values;
-                    for( std::size_t i = 0; i < PlonkTable::arithmetization_params::witness_columns; i++ ){
-                        for( std::size_t j = 0; j < assignments.rows_amount(); j++ ){
-                            table_values.push_back(assignments.witness(i)[j]);
-                        }
-                    }
-                    for( std::size_t i = 0; i < PlonkTable::arithmetization_params::public_input_columns; i++ ){
-                        for( std::size_t j = 0; j < assignments.rows_amount(); j++ ){
-                            table_values.push_back(assignments.public_input(i)[j]);
-                        }
-                    }
-                    for( std::size_t i = 0; i < PlonkTable::arithmetization_params::constant_columns; i++ ){
-                        for( std::size_t j = 0; j < assignments.rows_amount(); j++ ){
-                            table_values.push_back(assignments.constant(i)[j]);
-                        }
-                    }
-                    for( std::size_t i = 0; i < PlonkTable::arithmetization_params::selector_columns; i++ ){
-                        for( std::size_t j = 0; j < assignments.rows_amount(); j++ ){
-                            table_values.push_back(assignments.selector(i)[j]);
-                        }
-                    }
-                    return result_type(std::make_tuple(
+                    return result_type(std::move(std::make_tuple(
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>(assignments.witnesses_amount()),
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>(assignments.public_inputs_amount()),
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>(assignments.constants_amount()),
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>(assignments.selectors_amount()),
                         nil::marshalling::types::integral<TTypeBase, std::size_t>(usable_rows),
-                        nil::marshalling::types::integral<TTypeBase, std::size_t>(PlonkTable::arithmetization_params::total_columns),
-                        fill_field_element_vector<typename PlonkTable::field_type::value_type, Endianness>(table_values)
-                    ));
+                        nil::marshalling::types::integral<TTypeBase, std::size_t>(assignments.rows_amount()),
+                        fill_field_element_vector_from_columns_with_padding<value_type, Endianness>(
+                            assignments.witnesses(),
+                            assignments.rows_amount(),
+                            0
+                        ),
+                        fill_field_element_vector_from_columns_with_padding<value_type, Endianness>(
+                            assignments.public_inputs(),
+                            assignments.rows_amount(),
+                            0
+                        ),
+                        fill_field_element_vector_from_columns_with_padding<value_type, Endianness>(
+                            assignments.constants(),
+                            assignments.rows_amount(),
+                            0
+                        ),
+                        fill_field_element_vector_from_columns_with_padding<value_type, Endianness>(
+                            assignments.selectors(),
+                            assignments.rows_amount(),
+                            0
+                        )
+                    )));
                 }
                 template<typename Endianness, typename PlonkTable>
-                std::pair<std::size_t, PlonkTable> make_assignment_table(const plonk_assignment_table<nil::marshalling::field_type<Endianness>, PlonkTable> filled_assignments){
-                    auto values = make_field_element_vector<typename PlonkTable::field_type::value_type, Endianness>(std::get<2>(filled_assignments.value()));
-                    auto rows_amount = values.size()/PlonkTable::arithmetization_params::total_columns;
-                    std::size_t usable_rows =  std::get<0>(filled_assignments.value()).value();
+                std::pair<zk::snark::plonk_table_description<typename PlonkTable::field_type>, PlonkTable> make_assignment_table(
+                        const plonk_assignment_table<nil::marshalling::field_type<Endianness>, PlonkTable> &filled_assignments){
 
-                    // Size correctness check.
-                    if (PlonkTable::arithmetization_params::total_columns != std::get<1>(filled_assignments.value()).value() ||
-                        values.size() % PlonkTable::arithmetization_params::total_columns != 0
-                    )
-                        throw std::invalid_argument(
-                            "Invalid arithmetization params. Expected columns number = " +
-                            std::to_string(PlonkTable::arithmetization_params::total_columns) +
-                            ", real columns number = " +
-                            std::to_string(std::get<1>(filled_assignments.value()).value()) + ".");
+                    using value_type = typename PlonkTable::field_type::value_type;
 
-                    if ( usable_rows >= rows_amount )
+                    zk::snark::plonk_table_description<typename PlonkTable::field_type> desc(
+                        std::get<0>(filled_assignments.value()).value(),
+                        std::get<1>(filled_assignments.value()).value(),
+                        std::get<2>(filled_assignments.value()).value(),
+                        std::get<3>(filled_assignments.value()).value(),
+                        std::get<4>(filled_assignments.value()).value(),
+                        std::get<5>(filled_assignments.value()).value()
+                    );
+
+                    if ( desc.usable_rows_amount >= desc.rows_amount )
                         throw std::invalid_argument(
                             "Rows amount should be greater than usable rows amount. Rows amount = " +
-                            std::to_string(rows_amount) +
-                            ", usable rows amount = " + std::to_string(usable_rows));
+                            std::to_string(desc.rows_amount) +
+                            ", usable rows amount = " + std::to_string(desc.usable_rows_amount));
 
-                    typename PlonkTable::witnesses_container_type witnesses;
-                    std::size_t cur = 0;
-                    for(std::size_t i = 0; i < PlonkTable::arithmetization_params::witness_columns; i++){
-                        witnesses[i].resize(rows_amount);
-                        for(std::size_t j = 0; j < rows_amount; j++, cur++){
-                            witnesses[i][j] = values[cur];
-                        }
-                    }
-                    typename PlonkTable::public_input_container_type public_inputs;
-                    for(std::size_t i = 0; i < PlonkTable::arithmetization_params::public_input_columns; i++){
-                        public_inputs[i].resize(rows_amount);
-                        for(std::size_t j = 0; j < rows_amount; j++, cur++){
-                            public_inputs[i][j] = values[cur];
-                        }
-                    }
-                    typename PlonkTable::constant_container_type constants;
-                    for(std::size_t i = 0; i < PlonkTable::arithmetization_params::constant_columns; i++){
-                        constants[i].resize(rows_amount);
-                        for(std::size_t j = 0; j < rows_amount; j++, cur++){
-                            constants[i][j] = values[cur];
-                        }
-                    }
-                    typename PlonkTable::selector_container_type selectors;
-                    for(std::size_t i = 0; i < PlonkTable::arithmetization_params::selector_columns; i++){
-                        selectors[i].resize(rows_amount);
-                        for(std::size_t j = 0; j < rows_amount; j++, cur++){
-                            selectors[i][j] = values[cur];
-                        }
-                    }
-                    return std::make_pair( usable_rows, PlonkTable(
+                    std::vector<std::vector<value_type>> witnesses =
+                        make_field_element_columns_vector<value_type, Endianness>(
+                            std::get<6>(filled_assignments.value()),
+                            desc.witness_columns,
+                            desc.rows_amount
+                        );
+                    std::vector<std::vector<value_type>> public_inputs =
+                        make_field_element_columns_vector<value_type, Endianness>(
+                            std::get<7>(filled_assignments.value()),
+                            desc.public_input_columns,
+                            desc.rows_amount
+                        );
+                    std::vector<std::vector<value_type>> constants =
+                        make_field_element_columns_vector<value_type, Endianness>(
+                            std::get<8>(filled_assignments.value()),
+                            desc.constant_columns,
+                            desc.rows_amount
+                        );
+                    std::vector<std::vector<value_type>> selectors =
+                        make_field_element_columns_vector<value_type, Endianness>(
+                            std::get<9>(filled_assignments.value()),
+                            desc.selector_columns,
+                            desc.rows_amount
+                        );
+
+                    return std::make_pair(desc, PlonkTable(
                         typename PlonkTable::private_table_type(witnesses),
                         typename PlonkTable::public_table_type(public_inputs, constants, selectors)
                     ));

--- a/test/detail/circuits.hpp
+++ b/test/detail/circuits.hpp
@@ -92,11 +92,8 @@ namespace nil {
                 const std::size_t selector_columns_1 = 2;
                 const std::size_t rows_amount_1 = 13;
 
-                using arithmetization_params_1 = plonk_arithmetization_params<witness_columns_1,
-                    public_columns_1, constant_columns_1, selector_columns_1>;
-
                 template<typename FieldType>
-                circuit_description<FieldType, placeholder_circuit_params<FieldType, arithmetization_params_1>, rows_amount_1, 4> circuit_test_1(
+                circuit_description<FieldType, placeholder_circuit_params<FieldType>, rows_amount_1, 4> circuit_test_1(
                     typename nil::crypto3::random::algebraic_engine<FieldType> alg_rnd = nil::crypto3::random::algebraic_engine<FieldType>(),
                     boost::random::mt11213b rnd = boost::random::mt11213b()
                 ) {
@@ -112,7 +109,7 @@ namespace nil {
                     constexpr static const std::size_t table_columns =
                             witness_columns + public_columns + constant_columns;
 
-                    typedef placeholder_circuit_params<FieldType, arithmetization_params_1> circuit_params;
+                    typedef placeholder_circuit_params<FieldType> circuit_params;
                     circuit_description<FieldType, circuit_params, usable_rows, permutation> test_circuit;
                     std::array<std::vector<typename FieldType::value_type>, table_columns> table;
 
@@ -168,25 +165,25 @@ namespace nil {
                         test_circuit.copy_constraints.push_back(plonk_copy_constraint<FieldType>(x, y));
                     }
 
-                    std::array<plonk_column<FieldType>, witness_columns> private_assignment;
+                    std::vector<plonk_column<FieldType>> private_assignment(witness_columns);
                     for (std::size_t i = 0; i < witness_columns; i++) {
                         private_assignment[i] = table[i];
                     }
 
-                    std::array<plonk_column<FieldType>, selector_columns> selectors_assignment;
-                    std::array<plonk_column<FieldType>, public_columns> public_input_assignment;
-                    std::array<plonk_column<FieldType>, constant_columns> constant_assignment = {};
+                    std::vector<plonk_column<FieldType>> selectors_assignment(selector_columns);
+                    std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
+                    std::vector<plonk_column<FieldType>> constant_assignment(constant_columns);
 
                     selectors_assignment[0] = q_add;
                     selectors_assignment[1] = q_mul;
 
                     public_input_assignment[0] = table[3];
-                    test_circuit.table = plonk_assignment_table<FieldType, arithmetization_params_1>(
-                        plonk_private_assignment_table<FieldType, arithmetization_params_1>(private_assignment),
-                        plonk_public_assignment_table<FieldType, arithmetization_params_1>(
+                    test_circuit.table = plonk_assignment_table<FieldType>(
+                        plonk_private_assignment_table<FieldType>(private_assignment),
+                        plonk_public_assignment_table<FieldType>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
-                    test_circuit.table_rows = zk_padding<FieldType, arithmetization_params_1, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
+                    test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
                     plonk_variable<assignment_type> w0(0, 0, true, plonk_variable<assignment_type>::column_type::witness);
                     plonk_variable<assignment_type> w1(1, 0, true, plonk_variable<assignment_type>::column_type::witness);
@@ -232,11 +229,8 @@ namespace nil {
                 constexpr static const std::size_t selector_columns_t = 2;
                 constexpr static const std::size_t usable_rows_t = 5;
 
-                using arithmetization_params_t = plonk_arithmetization_params<witness_columns_t,
-                    public_columns_t, constant_columns_t, selector_columns_t>;
-
                 template<typename FieldType>
-                circuit_description<FieldType, placeholder_circuit_params<FieldType, arithmetization_params_t>, 5, 4>
+                circuit_description<FieldType, placeholder_circuit_params<FieldType>, 5, 4>
                 circuit_test_t(
                     typename FieldType::value_type pi0,// = 0,
                     typename nil::crypto3::random::algebraic_engine<FieldType> alg_rnd, //= nil::crypto3::random::algebraic_engine<FieldType>(),
@@ -252,7 +246,7 @@ namespace nil {
                     constexpr static const std::size_t table_columns =
                             witness_columns + public_columns + constant_columns;
 
-                    typedef placeholder_circuit_params<FieldType, arithmetization_params_t> circuit_params;
+                    typedef placeholder_circuit_params<FieldType> circuit_params;
 
                     circuit_description<FieldType, circuit_params, 5, permutation> test_circuit;
 
@@ -307,14 +301,14 @@ namespace nil {
                     table[3][1] = FieldType::value_type::zero();
                     table[3][2] = FieldType::value_type::one();
 
-                    std::array<plonk_column<FieldType>, witness_columns> private_assignment;
+                    std::vector<plonk_column<FieldType>> private_assignment(witness_columns);
                     for (std::size_t i = 0; i < witness_columns; i++) {
                         private_assignment[i] = table[i];
                     }
 
-                    std::array<plonk_column<FieldType>, selector_columns> selectors_assignment;
-                    std::array<plonk_column<FieldType>, public_columns> public_input_assignment;
-                    std::array<plonk_column<FieldType>, constant_columns> constant_assignment = {};
+                    std::vector<plonk_column<FieldType>> selectors_assignment(selector_columns);
+                    std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
+                    std::vector<plonk_column<FieldType>> constant_assignment(constant_columns);
 
                     selectors_assignment[0] = q_add;
                     selectors_assignment[1] = q_mul;
@@ -322,11 +316,11 @@ namespace nil {
                     for (std::size_t i = 0; i < public_columns; i++) {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
-                    test_circuit.table = plonk_assignment_table<FieldType, arithmetization_params_t>(
-                        plonk_private_assignment_table<FieldType, arithmetization_params_t>(private_assignment),
-                        plonk_public_assignment_table<FieldType, arithmetization_params_t>(
+                    test_circuit.table = plonk_assignment_table<FieldType>(
+                        plonk_private_assignment_table<FieldType>(private_assignment),
+                        plonk_public_assignment_table<FieldType>(
                             public_input_assignment, constant_assignment, selectors_assignment));
-                    test_circuit.table_rows = zk_padding<FieldType, arithmetization_params_t, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
+                    test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
                     plonk_variable<assignment_type> w0(0, 0, true,
                                                  plonk_variable<assignment_type>::column_type::witness);
@@ -368,11 +362,8 @@ namespace nil {
                 constexpr static const std::size_t usable_rows_3 = 4;
                 constexpr static const std::size_t permutation_size_3 = 3;
 
-                using arithmetization_params_3 = plonk_arithmetization_params<witness_columns_3,
-                    public_columns_3, constant_columns_3, selector_columns_3>;
-
                 template<typename FieldType>
-                circuit_description<FieldType, placeholder_circuit_params<FieldType, arithmetization_params_3>, usable_rows_3, permutation_size_3> circuit_test_3(
+                circuit_description<FieldType, placeholder_circuit_params<FieldType>, usable_rows_3, permutation_size_3> circuit_test_3(
                     typename nil::crypto3::random::algebraic_engine<FieldType> alg_rnd = nil::crypto3::random::algebraic_engine<FieldType>(),
                     boost::random::mt11213b rnd = boost::random::mt11213b()
                 ) {
@@ -387,7 +378,7 @@ namespace nil {
                             witness_columns + public_columns + constant_columns;
                     constexpr static const std::size_t usable_rows = usable_rows_3;
 
-                    typedef placeholder_circuit_params<FieldType, arithmetization_params_3> circuit_params;
+                    typedef placeholder_circuit_params<FieldType> circuit_params;
 
                     circuit_description<FieldType, circuit_params, usable_rows, permutation> test_circuit;
 
@@ -412,15 +403,15 @@ namespace nil {
                     table[4] = {0, 0,  1, 0}; //Lookup values
                     table[5] = {0, 1,  0, 0}; //Lookup values
 
-                    std::array<plonk_column<FieldType>, witness_columns> private_assignment;
+                    std::vector<plonk_column<FieldType>> private_assignment(witness_columns);
                     for (std::size_t i = 0; i < witness_columns; i++) {
                         private_assignment[i] = table[i];
                     }
 
-                    std::array<plonk_column<FieldType>, public_columns> public_input_assignment = {};
+                    std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
 
-                    std::array<plonk_column<FieldType>, selector_columns> selectors_assignment;
-                    std::array<plonk_column<FieldType>, constant_columns> constant_assignment;
+                    std::vector<plonk_column<FieldType>> selectors_assignment(selector_columns);
+                    std::vector<plonk_column<FieldType>> constant_assignment(constant_columns);
 
                     std::vector<typename FieldType::value_type> sel_lookup(test_circuit.table_rows);
                     sel_lookup = {1, 0, 0, 0};
@@ -433,9 +424,9 @@ namespace nil {
                     for (std::size_t i = 0; i < constant_columns; i++) {
                         constant_assignment[i] = table[witness_columns + i];
                     }
-                    test_circuit.table = plonk_assignment_table<FieldType, arithmetization_params_3>(
-                        plonk_private_assignment_table<FieldType, arithmetization_params_3>(private_assignment),
-                        plonk_public_assignment_table<FieldType, arithmetization_params_3>(
+                    test_circuit.table = plonk_assignment_table<FieldType>(
+                        plonk_private_assignment_table<FieldType>(private_assignment),
+                        plonk_public_assignment_table<FieldType>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -485,12 +476,8 @@ namespace nil {
                 constexpr static const std::size_t constant_columns_4 = 3;
                 constexpr static const std::size_t selector_columns_4 = 3;
 
-                using arithmetization_params_4 = plonk_arithmetization_params<witness_columns_4,
-                    public_columns_4, constant_columns_4, selector_columns_4>;
-
                 template<typename FieldType>
-                circuit_description<FieldType, placeholder_circuit_params<FieldType,
-                    arithmetization_params_4>, 3, 3> circuit_test_4(
+                circuit_description<FieldType, placeholder_circuit_params<FieldType>, 3, 3> circuit_test_4(
                         typename nil::crypto3::random::algebraic_engine<FieldType> alg_rnd = nil::crypto3::random::algebraic_engine<FieldType>(),
                         boost::random::mt11213b rnd = boost::random::mt11213b()
                     ) {
@@ -506,7 +493,7 @@ namespace nil {
                     constexpr static const std::size_t table_columns =
                             witness_columns + public_columns + constant_columns;
 
-                    typedef placeholder_circuit_params<FieldType, arithmetization_params_4> circuit_params;
+                    typedef placeholder_circuit_params<FieldType> circuit_params;
 
                     circuit_description<FieldType, circuit_params, rows_log, permutation> test_circuit;
 
@@ -527,14 +514,14 @@ namespace nil {
                     table[4] = {0, 0, 1, 0, 1, 0, 0, 0};
                     table[5] = {0, 0, 0, 0, 1, 0, 0, 0};
 
-                    std::array<plonk_column<FieldType>, witness_columns> private_assignment;
+                    std::vector<plonk_column<FieldType>> private_assignment(witness_columns);
                     for (std::size_t i = 0; i < witness_columns; i++) {
                         private_assignment[i] = table[i];
                     }
 
-                    std::array<plonk_column<FieldType>, selector_columns> selectors_assignment;
-                    std::array<plonk_column<FieldType>, public_columns> public_input_assignment = {};
-                    std::array<plonk_column<FieldType>, constant_columns> constant_assignment;
+                    std::vector<plonk_column<FieldType>> selectors_assignment(selector_columns);
+                    std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
+                    std::vector<plonk_column<FieldType>> constant_assignment(constant_columns);
 
                     std::vector<typename FieldType::value_type> sel_lookup(test_circuit.table_rows);
                     sel_lookup ={1, 1, 0, 1, 1, 0, 0, 0};
@@ -552,9 +539,9 @@ namespace nil {
                     for (std::size_t i = 0; i < constant_columns; i++) {
                         constant_assignment[i] = table[witness_columns + i];
                     }
-                    test_circuit.table = plonk_assignment_table<FieldType, arithmetization_params_4>(
-                        plonk_private_assignment_table<FieldType, arithmetization_params_4>(private_assignment),
-                        plonk_public_assignment_table<FieldType, arithmetization_params_4>(
+                    test_circuit.table = plonk_assignment_table<FieldType>(
+                        plonk_private_assignment_table<FieldType>(private_assignment),
+                        plonk_public_assignment_table<FieldType>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
                     plonk_variable<assignment_type> w0(0, 0, true, plonk_variable<assignment_type>::column_type::witness);
@@ -610,11 +597,8 @@ namespace nil {
                 constexpr static const std::size_t constant_columns_fib = 0;
                 constexpr static const std::size_t selector_columns_fib = 1;
 
-                using arithmetization_params_fib = plonk_arithmetization_params<witness_columns_fib,
-                    public_columns_fib, constant_columns_fib, selector_columns_fib>;
-
                 template<typename FieldType, std::size_t usable_rows>
-                circuit_description<FieldType, placeholder_circuit_params<FieldType, arithmetization_params_fib>, usable_rows, 2>
+                circuit_description<FieldType, placeholder_circuit_params<FieldType>, usable_rows, 2>
                 circuit_test_fib(
                     typename nil::crypto3::random::algebraic_engine<FieldType> alg_rnd = nil::crypto3::random::algebraic_engine<FieldType>()
                 ) {
@@ -629,7 +613,7 @@ namespace nil {
                     constexpr static const std::size_t table_columns =
                             witness_columns + public_columns + selector_columns;
 
-                    typedef placeholder_circuit_params<FieldType, arithmetization_params_fib> circuit_params;
+                    typedef placeholder_circuit_params<FieldType> circuit_params;
 
                     circuit_description<FieldType, circuit_params, usable_rows, permutation> test_circuit;
                     std::array<std::vector<typename FieldType::value_type>, table_columns> table;
@@ -668,12 +652,12 @@ namespace nil {
                         table[2][i-1] = one;
                     }
 
-                    std::array<plonk_column<FieldType>, witness_columns> private_assignment;
+                    std::vector<plonk_column<FieldType>> private_assignment(witness_columns);
                     private_assignment[0] = table[0];
 
-                    std::array<plonk_column<FieldType>, selector_columns> selectors_assignment;
-                    std::array<plonk_column<FieldType>, public_columns> public_input_assignment;
-                    std::array<plonk_column<FieldType>, constant_columns> constant_assignment = {};
+                    std::vector<plonk_column<FieldType>> selectors_assignment(selector_columns);
+                    std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
+                    std::vector<plonk_column<FieldType>> constant_assignment(constant_columns);
 
                     selectors_assignment[0] = table[2];
 
@@ -681,11 +665,11 @@ namespace nil {
                     selectors_assignment[0] = table[2];
 
 
-                    test_circuit.table = plonk_assignment_table<FieldType, arithmetization_params_fib>(
-                        plonk_private_assignment_table<FieldType, arithmetization_params_fib>(private_assignment),
-                        plonk_public_assignment_table<FieldType, arithmetization_params_fib>(
+                    test_circuit.table = plonk_assignment_table<FieldType>(
+                        plonk_private_assignment_table<FieldType>(private_assignment),
+                        plonk_public_assignment_table<FieldType>(
                             public_input_assignment, constant_assignment, selectors_assignment));
-                    test_circuit.table_rows = zk_padding<FieldType, arithmetization_params_fib, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
+                    test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
                     plonk_variable<assignment_type> w0(0, -1, true, plonk_variable<assignment_type>::column_type::witness);
                     plonk_variable<assignment_type> w1(0, 0, true, plonk_variable<assignment_type>::column_type::witness);
@@ -732,12 +716,8 @@ namespace nil {
                 constexpr static const std::size_t selector_columns_6 = 3;
                 constexpr static const std::size_t usable_rows_6 = 6;
 
-                using arithmetization_params_6 = plonk_arithmetization_params<witness_columns_6,
-                    public_columns_6, constant_columns_6, selector_columns_6>;
-
                 template<typename FieldType>
-                circuit_description<FieldType, placeholder_circuit_params<FieldType,
-                    arithmetization_params_6>, usable_rows_6, 3> circuit_test_6(
+                circuit_description<FieldType, placeholder_circuit_params<FieldType>, usable_rows_6, 3> circuit_test_6(
                         typename nil::crypto3::random::algebraic_engine<FieldType> alg_rnd = nil::crypto3::random::algebraic_engine<FieldType>(),
                         boost::random::mt11213b rnd = boost::random::mt11213b()
                     ) {
@@ -752,7 +732,7 @@ namespace nil {
                     constexpr static const std::size_t table_columns =
                             witness_columns + public_columns + constant_columns + selector_columns;
 
-                    typedef placeholder_circuit_params<FieldType, arithmetization_params_6> circuit_params;
+                    typedef placeholder_circuit_params<FieldType> circuit_params;
 
                     circuit_description<FieldType, circuit_params, usable_rows_6, permutation> test_circuit;
 
@@ -777,14 +757,14 @@ namespace nil {
                     table[6] = {0,  7,  8,  9, 10, 11}; // L2
                     table[7] = {0, 12, 12, 12, 12, 12}; // L3
 
-                    std::array<plonk_column<FieldType>, witness_columns> private_assignment;
+                    std::vector<plonk_column<FieldType>> private_assignment(witness_columns);
                     for (std::size_t i = 0; i < witness_columns; i++) {
                         private_assignment[i] = table[i];
                     }
 
-                    std::array<plonk_column<FieldType>, selector_columns> selectors_assignment;
-                    std::array<plonk_column<FieldType>, public_columns> public_input_assignment = {};
-                    std::array<plonk_column<FieldType>, constant_columns> constant_assignment;
+                    std::vector<plonk_column<FieldType>> selectors_assignment(selector_columns);
+                    std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
+                    std::vector<plonk_column<FieldType>> constant_assignment(constant_columns);
 
                     selectors_assignment[0] = table[2];
                     selectors_assignment[1] = table[3];
@@ -793,9 +773,9 @@ namespace nil {
                     for (std::size_t i = 0; i < constant_columns; i++) {
                         constant_assignment[i] = table[witness_columns + selector_columns + i];
                     }
-                    test_circuit.table = plonk_assignment_table<FieldType, arithmetization_params_6>(
-                        plonk_private_assignment_table<FieldType, arithmetization_params_6>(private_assignment),
-                        plonk_public_assignment_table<FieldType, arithmetization_params_6>(
+                    test_circuit.table = plonk_assignment_table<FieldType>(
+                        plonk_private_assignment_table<FieldType>(private_assignment),
+                        plonk_public_assignment_table<FieldType>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -879,12 +859,8 @@ namespace nil {
                 constexpr static const std::size_t selector_columns_7 = 6;
                 constexpr static const std::size_t usable_rows_7 = 14;
 
-                using arithmetization_params_7 = plonk_arithmetization_params<witness_columns_7,
-                    public_columns_7, constant_columns_7, selector_columns_7>;
-
                 template<typename FieldType>
-                circuit_description<FieldType, placeholder_circuit_params<FieldType,
-                    arithmetization_params_7>, usable_rows_7, 4> circuit_test_7(
+                circuit_description<FieldType, placeholder_circuit_params<FieldType>, usable_rows_7, 4> circuit_test_7(
                         typename nil::crypto3::random::algebraic_engine<FieldType> alg_rnd = nil::crypto3::random::algebraic_engine<FieldType>(),
                         boost::random::mt11213b rnd = boost::random::mt11213b()
                     ) {
@@ -899,7 +875,7 @@ namespace nil {
                     constexpr static const std::size_t table_columns =
                             witness_columns + public_columns + constant_columns + selector_columns;
 
-                    typedef placeholder_circuit_params<FieldType, arithmetization_params_7> circuit_params;
+                    typedef placeholder_circuit_params<FieldType> circuit_params;
 
                     circuit_description<FieldType, circuit_params, usable_rows_7, permutation> test_circuit;
 
@@ -925,7 +901,7 @@ namespace nil {
 
                     // selectors
                     // Reserved zero row for unselected lookup input rows
-                    std::array<plonk_column<FieldType>, selector_columns> selectors_assignment;
+                    std::vector<plonk_column<FieldType>> selectors_assignment(selector_columns);
                     selectors_assignment[0] = {0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1 }; // Selector for single gate
                     selectors_assignment[1] = {0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0 }; // Selector lookup gate with multiple rotations
                     selectors_assignment[2] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }; // Selector for gate w1 = 2^w0
@@ -934,7 +910,7 @@ namespace nil {
                     selectors_assignment[5] = {0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0 }; // Selector for lookup table with 7 columns
 
                     // Lookup values
-                    std::array<plonk_column<FieldType>, constant_columns> constant_assignment;
+                    std::vector<plonk_column<FieldType>> constant_assignment(constant_columns);
                     constant_assignment[0] = {0, 1, 0, 0, 0, 0, 0, 0,   0,   1,    2,    3,    4,    5 }; // Lookup tables
                     constant_assignment[1] = {0, 2, 2, 1, 1, 1, 1, 1,   1,   2,    4,    8,   16,   32 }; // Lookup tables
                     constant_assignment[2] = {0, 3, 3, 3, 2, 2, 2, 2,   6,   7,    7,    7,    7,    7 }; // Lookup tables
@@ -943,16 +919,16 @@ namespace nil {
                     constant_assignment[5] = {0, 6, 6, 6, 6, 6, 6, 5,  64, 128,  256,  512, 1024, 2048 }; // Lookup tables
                     constant_assignment[6] = {0, 7, 7, 7, 7, 7, 7, 7,4096,8192,16384,16384,16384,16384 }; // Lookup tables
 
-                    std::array<plonk_column<FieldType>, witness_columns> private_assignment;
+                    std::vector<plonk_column<FieldType>> private_assignment(witness_columns);
                     for (std::size_t i = 0; i < witness_columns; i++) {
                         private_assignment[i] = table[i];
                     }
 
-                    std::array<plonk_column<FieldType>, public_columns> public_input_assignment = {};
+                    std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
 
-                    test_circuit.table = plonk_assignment_table<FieldType, arithmetization_params_7>(
-                        plonk_private_assignment_table<FieldType, arithmetization_params_7>(private_assignment),
-                        plonk_public_assignment_table<FieldType, arithmetization_params_7>(
+                    test_circuit.table = plonk_assignment_table<FieldType>(
+                        plonk_private_assignment_table<FieldType>(private_assignment),
+                        plonk_public_assignment_table<FieldType>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 

--- a/test/merkle_proof.cpp
+++ b/test/merkle_proof.cpp
@@ -95,7 +95,7 @@ generate_random_data(std::size_t leaf_number) {
     return v;
 }
 
-template<typename Endianness, typename Hash, std::size_t Arity, std::size_t LeafSize = 32>
+template<typename Endianness, typename Hash, std::size_t Arity, std::size_t LeafSize = 64>
 void test_merkle_proof(std::size_t tree_depth) {
 
     using namespace nil::crypto3::marshalling;
@@ -145,7 +145,7 @@ using HashTypes = boost::mpl::list<
         std::srand(std::time(0));
         test_merkle_proof<nil::marshalling::option::big_endian, HashType, 2>(5);
         test_merkle_proof<nil::marshalling::option::big_endian, HashType, 2>(10);
-        test_merkle_proof<nil::marshalling::option::big_endian, HashType, 2, 300>(15);
+        test_merkle_proof<nil::marshalling::option::big_endian, HashType, 2, 320>(15);
     }
 
 // Poseidon hash function supports only Arity 2.

--- a/test/placeholder_common_data.cpp
+++ b/test/placeholder_common_data.cpp
@@ -216,13 +216,10 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit1)
         constexpr static const std::size_t constant_columns = constant_columns_1;
         constexpr static const std::size_t selector_columns = selector_columns_1;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
-    typedef placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params> circuit_params;
+    typedef placeholder_circuit_params<field_type> circuit_params;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<transcript_hash_type>;
 
     using lpc_params_type = commitments::list_polynomial_commitment_params<
@@ -241,7 +238,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit1)
 BOOST_AUTO_TEST_CASE(prover_test) {
     auto circuit = circuit_test_1<field_type>();
 
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = placeholder_test_params::table_rows;
     desc.usable_rows_amount = placeholder_test_params::usable_rows;
@@ -288,16 +290,10 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit2)
         constexpr static const std::size_t constant_columns = 0;
         constexpr static const std::size_t selector_columns = 2;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 1;
         constexpr static const std::size_t m = 2;
     };
-    using circuit_t_params = placeholder_circuit_params<
-        field_type,
-        typename placeholder_test_params::arithmetization_params
-    >;
+    using circuit_t_params = placeholder_circuit_params<field_type>;
 
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
 
@@ -318,7 +314,12 @@ BOOST_AUTO_TEST_CASE(common_data_marshalling_test) {
     auto pi0 = nil::crypto3::algebra::random_element<field_type>();
     auto circuit = circuit_test_t<field_type>(pi0, test_global_alg_rnd_engine<field_type>, test_global_rnd_engine);
 
-    plonk_table_description<field_type, typename circuit_t_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
 
@@ -364,14 +365,11 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit3)
         constexpr static const std::size_t constant_columns = constant_columns_3;
         constexpr static const std::size_t selector_columns = selector_columns_3;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
 
-    using circuit_params = placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params>;
+    using circuit_params = placeholder_circuit_params<field_type>;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
     using lpc_params_type = commitments::list_polynomial_commitment_params<
         typename placeholder_test_params::merkle_hash_type,
@@ -389,7 +387,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit3)
 BOOST_FIXTURE_TEST_CASE(proof_marshalling_test, test_initializer) {
     auto circuit = circuit_test_3<field_type>();
 
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
@@ -439,14 +442,11 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit4)
         constexpr static const std::size_t constant_columns = constant_columns_4;
         constexpr static const std::size_t selector_columns = selector_columns_4;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
 
-    using circuit_params = placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params>;
+    using circuit_params = placeholder_circuit_params<field_type>;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
     using lpc_params_type = commitments::list_polynomial_commitment_params<
         typename placeholder_test_params::merkle_hash_type,
@@ -464,7 +464,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit4)
 BOOST_FIXTURE_TEST_CASE(proof_marshalling_test, test_initializer) {
     auto circuit = circuit_test_4<field_type>();
 
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
@@ -516,16 +521,10 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit5)
         constexpr static const std::size_t constant_columns = 0;
         constexpr static const std::size_t selector_columns = 2;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 1;
         constexpr static const std::size_t m = 2;
     };
-    using circuit_t_params = placeholder_circuit_params<
-        field_type,
-        typename placeholder_test_params::arithmetization_params
-    >;
+    using circuit_t_params = placeholder_circuit_params<field_type>;
 
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
 
@@ -547,7 +546,12 @@ BOOST_AUTO_TEST_CASE(common_data_marshalling_test) {
     auto pi1 = nil::crypto3::algebra::random_element<field_type>();
     auto circuit = circuit_test_t<field_type>(pi0, pi1, test_global_alg_rnd_engine<field_type>);
 
-    plonk_table_description<field_type, typename circuit_t_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
 
@@ -595,14 +599,11 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit6)
         constexpr static const std::size_t constant_columns = constant_columns_6;
         constexpr static const std::size_t selector_columns = selector_columns_6;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
 
-    using circuit_params = placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params>;
+    using circuit_params = placeholder_circuit_params<field_type>;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
     using lpc_params_type = commitments::list_polynomial_commitment_params<
         typename placeholder_test_params::merkle_hash_type,
@@ -620,7 +621,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit6)
 BOOST_FIXTURE_TEST_CASE(proof_marshalling_test, test_initializer) {
     auto circuit = circuit_test_6<field_type>();
 
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
@@ -667,14 +673,11 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit7)
         constexpr static const std::size_t constant_columns = constant_columns_7;
         constexpr static const std::size_t selector_columns = selector_columns_7;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
 
-    using circuit_params = placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params>;
+    using circuit_params = placeholder_circuit_params<field_type>;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
     using lpc_params_type = commitments::list_polynomial_commitment_params<
         typename placeholder_test_params::merkle_hash_type,
@@ -691,7 +694,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit7)
 
 BOOST_FIXTURE_TEST_CASE(proof_marshalling_test, test_initializer) {
     auto circuit = circuit_test_7<field_type>();
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = circuit.table_rows;
     desc.usable_rows_amount = circuit.usable_rows;

--- a/test/plonk_constraint_system.cpp
+++ b/test/plonk_constraint_system.cpp
@@ -165,13 +165,10 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit1)
         constexpr static const std::size_t constant_columns = constant_columns_1;
         constexpr static const std::size_t selector_columns = selector_columns_1;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
-    typedef placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params> circuit_params;
+    typedef placeholder_circuit_params<field_type> circuit_params;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<transcript_hash_type>;
 
     using lpc_params_type = commitments::list_polynomial_commitment_params<
@@ -190,7 +187,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit1)
 BOOST_FIXTURE_TEST_CASE(constraint_system_marshalling_test, test_initializer) {
     auto circuit = circuit_test_1<field_type>();
 
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = placeholder_test_params::table_rows;
     desc.usable_rows_amount = placeholder_test_params::usable_rows;
@@ -225,16 +227,10 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit2)
         constexpr static const std::size_t constant_columns = 0;
         constexpr static const std::size_t selector_columns = 2;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 1;
         constexpr static const std::size_t m = 2;
     };
-    using circuit_t_params = placeholder_circuit_params<
-        field_type,
-        typename placeholder_test_params::arithmetization_params
-    >;
+    using circuit_t_params = placeholder_circuit_params<field_type>;
 
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
 
@@ -255,7 +251,12 @@ BOOST_FIXTURE_TEST_CASE(constraint_system_marshalling_test, test_initializer) {
     auto pi0 = nil::crypto3::algebra::random_element<field_type>();
     auto circuit = circuit_test_t<field_type>(pi0, test_global_alg_rnd_engine<field_type>, test_global_rnd_engine);
 
-    plonk_table_description<field_type, typename circuit_t_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
 
@@ -288,14 +289,11 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit3)
         constexpr static const std::size_t constant_columns = constant_columns_3;
         constexpr static const std::size_t selector_columns = selector_columns_3;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
 
-    using circuit_params = placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params>;
+    using circuit_params = placeholder_circuit_params<field_type>;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
     using lpc_params_type = commitments::list_polynomial_commitment_params<
         typename placeholder_test_params::merkle_hash_type,
@@ -313,7 +311,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit3)
 BOOST_FIXTURE_TEST_CASE(constraint_system_marshalling_test, test_initializer) {
     auto circuit = circuit_test_3<field_type>();
 
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
@@ -353,14 +356,11 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit4)
         constexpr static const std::size_t constant_columns = constant_columns_4;
         constexpr static const std::size_t selector_columns = selector_columns_4;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
 
-    using circuit_params = placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params>;
+    using circuit_params = placeholder_circuit_params<field_type>;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
     using lpc_params_type = commitments::list_polynomial_commitment_params<
         typename placeholder_test_params::merkle_hash_type,
@@ -378,7 +378,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit4)
 BOOST_FIXTURE_TEST_CASE(constraint_system_marshalling_test, test_initializer) {
     auto circuit = circuit_test_4<field_type>();
 
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
@@ -420,16 +425,10 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit5)
         constexpr static const std::size_t constant_columns = 0;
         constexpr static const std::size_t selector_columns = 2;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 1;
         constexpr static const std::size_t m = 2;
     };
-    using circuit_t_params = placeholder_circuit_params<
-        field_type,
-        typename placeholder_test_params::arithmetization_params
-    >;
+    using circuit_t_params = placeholder_circuit_params<field_type>;
 
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
 
@@ -451,7 +450,12 @@ BOOST_FIXTURE_TEST_CASE(constraint_system_marshalling_test, test_initializer) {
     auto pi1 = nil::crypto3::algebra::random_element<field_type>();
     auto circuit = circuit_test_t<field_type>(pi0, pi1);
 
-    plonk_table_description<field_type, typename circuit_t_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
 
@@ -485,14 +489,11 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit6)
         constexpr static const std::size_t constant_columns = constant_columns_6;
         constexpr static const std::size_t selector_columns = selector_columns_6;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
 
-    using circuit_params = placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params>;
+    using circuit_params = placeholder_circuit_params<field_type>;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
     using lpc_params_type = commitments::list_polynomial_commitment_params<
         typename placeholder_test_params::merkle_hash_type,
@@ -510,7 +511,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit6)
 BOOST_FIXTURE_TEST_CASE(constraint_system_marshalling_test, test_initializer) {
     auto circuit = circuit_test_6<field_type>();
 
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;
@@ -548,14 +554,11 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit7)
         constexpr static const std::size_t constant_columns = constant_columns_7;
         constexpr static const std::size_t selector_columns = selector_columns_7;
 
-        using arithmetization_params =
-            plonk_arithmetization_params<witness_columns, public_input_columns, constant_columns, selector_columns>;
-
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t m = 2;
     };
 
-    using circuit_params = placeholder_circuit_params<field_type, typename placeholder_test_params::arithmetization_params>;
+    using circuit_params = placeholder_circuit_params<field_type>;
     using transcript_type = typename transcript::fiat_shamir_heuristic_sequential<typename placeholder_test_params::transcript_hash_type>;
     using lpc_params_type = commitments::list_polynomial_commitment_params<
         typename placeholder_test_params::merkle_hash_type,
@@ -572,7 +575,12 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit7)
 
 BOOST_FIXTURE_TEST_CASE(constraint_system_marshalling_test, test_initializer) {
     auto circuit = circuit_test_7<field_type>();
-    plonk_table_description<field_type, typename circuit_params::arithmetization_params> desc;
+    plonk_table_description<field_type> desc(
+        placeholder_test_params::witness_columns,
+        placeholder_test_params::public_input_columns,
+        placeholder_test_params::constant_columns,
+        placeholder_test_params::selector_columns
+    );
 
     desc.rows_amount = table_rows;
     desc.usable_rows_amount = usable_rows;


### PR DESCRIPTION
Closes https://github.com/NilFoundation/crypto3-zk-marshalling/issues/85.